### PR TITLE
cargo: bump skeptic dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ readme = "README.md"
 license = "MIT/Apache-2.0"
 
 [build-dependencies]
-skeptic = "0.4.0"
+skeptic = "0.9"
 
 [dependencies]
 
 [dev-dependencies]
-skeptic = "0.4.0"
+skeptic = "0.9"


### PR DESCRIPTION
This bumps skeptic to latest 0.9.x.